### PR TITLE
Poprawka dla filtrowania po grupach

### DIFF
--- a/PepperTweaker.user.js
+++ b/PepperTweaker.user.js
@@ -2955,6 +2955,48 @@
             }
           }
 
+          /**
+           * Extracts the groups list from the provided HTML document.
+           * @param {Document} htmlDoc - The HTML document to extract the groups list from.
+           * @returns {Array<string>} - The list of group names found in the HTML document.
+           */
+          const getGroupsListFromDocument = (htmlDoc) => {
+            try {
+              // Get all script elements in the document
+              const scriptElements = htmlDoc.getElementsByTagName('script');
+
+              // Iterate through the script elements
+              for (let scriptElement of scriptElements) {
+                const content = scriptElement.textContent;
+
+                // If the content doesn't include "window.__INITIAL_STATE__", move to the next script element
+                if (!content.includes('window.__INITIAL_STATE__')) {
+                  continue;
+                }
+
+                // Attempt to match the content against the regex
+                const match = content.match(/window\.__INITIAL_STATE__\s*=\s*(\{[\s\S]*?\});/);
+
+                // If there's no match or the match doesn't contain the JSON object, move to the next script element
+                if (!match || !match[1]) {
+                  continue;
+                }
+
+                // Parse the JSON object from the matched string
+                const initialState = JSON.parse(match[1]);
+
+                // Extract the groups list from the initialState object and return it
+                return initialState.threadDetail?.groupsPath?.map(({ threadGroupName }) => threadGroupName) || [];
+              }
+            } catch (error) {
+              // Log an error message if something goes wrong during processing
+              console.error('An error occurred while processing the page:', error);
+              return [];
+            }
+            // Return an empty array if no matching elements were found
+            return [];
+          }
+
           const link = element.querySelector('a.cept-tt');
           if (deepSearch && link && link.href && link.href.length > 0) {
             fetch(link.href)
@@ -2966,11 +3008,7 @@
               })
               .then(text => {
                 let htmlDoc = (new DOMParser()).parseFromString(text, 'text/html');
-                const groupLinks = htmlDoc.documentElement.querySelectorAll('.overflow--ellipsis a[href*="/grupa/"]');
-                const groups = [];
-                for (const groupLink of groupLinks) {
-                  groups.push(groupLink.textContent);
-                }
+                const groups = getGroupsListFromDocument(htmlDoc);
 
                 const locationIcon = htmlDoc.documentElement.querySelector('*[id^="thread"] .cept-thread-content svg.icon--location');
                 const local = locationIcon !== null && locationIcon.parentNode.parentNode.textContent.search(/Ogólnopolska/i) < 0;

--- a/PepperTweaker.user.js
+++ b/PepperTweaker.user.js
@@ -2969,11 +2969,6 @@
               for (let scriptElement of scriptElements) {
                 const content = scriptElement.textContent;
 
-                // If the content doesn't include "window.__INITIAL_STATE__", move to the next script element
-                if (!content.includes('window.__INITIAL_STATE__')) {
-                  continue;
-                }
-
                 // Attempt to match the content against the regex
                 const match = content.match(/window\.__INITIAL_STATE__\s*=\s*(\{[\s\S]*?\});/);
 

--- a/PepperTweaker.user.js
+++ b/PepperTweaker.user.js
@@ -2966,7 +2966,7 @@
               const scriptElements = htmlDoc.getElementsByTagName('script');
 
               // Iterate through the script elements
-              for (let scriptElement of scriptElements) {
+              for (const scriptElement of scriptElements) {
                 const content = scriptElement.textContent;
 
                 // Attempt to match the content against the regex


### PR DESCRIPTION
Najprawdopodobniej po zmianach po stronie Peppera, przestało działać filtrowania po grupach, ten PR je naprawia.

Problem leżał w tym, że w zwracanym HTML nie ma już wyrenderowanych breadcrumbsów, bo dzieje się to dopiero na kliencie, przez komponent Vue.js, wiec tablica z grupami danej oferty zawsze była pusta.

Problem rozwiązałem wyciągając dane z obiektu, który jest używany do hydracji komponentów renderujących UI na kliencie.

Kod jest mocno wypchany kapkę oczywistymi komentarzami, żeby się nie trzeba było za wiele domyślać, ale oczywiście mogę to wyrzucić, żeby stylem pasowało do reszty projektu.