### PR TITLE
Fixed display property causing price to be cut off on Safari

### DIFF
--- a/PepperTweaker.user.js
+++ b/PepperTweaker.user.js
@@ -3556,12 +3556,17 @@
               height: 8.8em;
               text-overflow: ellipsis;
               overflow: hidden;
-              display: -webkit-box;
-              -webkit-line-clamp: 3;
-              -webkit-box-orient: vertical;
               font-size: 1rem !important;
               line-height: 1.5rem !important;
               --line-height: 1.5rem !important;
+            }
+            /* For non-Safari browsers */
+            @supports not (-webkit-hyphens:none) {
+              .threadListCard-body {
+                display: -webkit-box;
+                -webkit-line-clamp: 3;
+                -webkit-box-orient: vertical;
+              }
             }
             @media (min-width: 48em) {
               .threadListCard-body {


### PR DESCRIPTION
This will fix the price being cut off on Safari browser (see the attached screenshot) by excluding it from setting the `display: -webkit-box` property. 

<img width="951" alt="image" src="https://github.com/user-attachments/assets/b177b442-40b3-497c-953e-8ff6e344aa54" />
